### PR TITLE
Add consistent naming and a sample project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+# Ignore all files without a ending
+*
+!*.*
+!*/
+!makefile
+
 version.*
 .vscode
 test
 *.out
+*.o

--- a/README.md
+++ b/README.md
@@ -12,41 +12,40 @@ Use one of the following schemas for your Git tags as described in [Semver2.0.0]
 v2.3.4-beta
 ```
 
-## Available expressions
-Expression | Usage | Example | Flag to disable
+## Available variables
+Name | Usage | Example | Flag to disable
 -- | -- | -- | --
-#GITURL | The url of this GitRepo | www.github.com/username/repo | GH_NO_URL
-#VERSION | tag-offset-gitHash-dirtyFlag from git describe | v1.0.23-3-g354377c-dirty | GH_NO_TEXT
-#DATE | Date of compilation | 2021-09-19 | GH_NO_TEXT
-#TIME | Time of compilation | 17:06:40 | GH_NO_TEXT
-#UNXITIME | Unixtimestamp of compilation | 1653459717 | GH_NO_RAW
-#MAJOR | Major version | 1 | GH_NO_RAW
-#MINOR | Minor version | 1 | GH_NO_RAW
-#PATCH | Patch | 23 | GH_NO_RAW
-#PRERELEASE | Prerelease | alpha / alpha.2 / alpha.beta | GH_NO_RAW
-#OFFSET | Amount of commits ahead this tag | 3 | GH_NO_RAW
-#GITHASHHEX | GitHash(n=7) as HexValue | 0x354377c | GH_NO_RAW
-#DIRTYFLAG | 1 for uncommited changes, else 0 | 1 | GH_NO_RAW
+gitURL | The url of this GitRepo | username/repo | GH_NO_URL
+gitVersion | info from git describe | v1.0.23-3-g354377c-dirty | GH_NO_TEXT
+compDate | Date of compilation | 2021-09-19 | GH_NO_TEXT
+compTime | Time of compilation | 17:06:40 | GH_NO_TEXT
+compUnixTime | Unix timestamp of compilation | 1653459717 | GH_NO_RAW
+tagArray | Array with Major.Minor.Patch | 1.0.23 | GH_NO_RAW
+tagPreRelease | Prerelease as string | alpha / alpha.2 / alpha.beta | GH_NO_RAW
+tagOffset | Amount of commits ahead this tag | 3 | GH_NO_RAW
+gitHash | GitHash(n=7) as HexValue | 0x354377c | GH_NO_RAW
+gitDirty | 1 for uncommited changes, else 0 | 1 | GH_NO_RAW
 
 ## Example [template](template/templateCpp.h) after build
 ```
 namespace version
 {
     #ifndef GH_NO_URL
-    constexpr char gitURL[] = "user/Repo";
+	constexpr char gitURL[] = "";
     #endif
     #ifndef GH_NO_TEXT
-    constexpr char gitHash[] = "v1.1.23-alpha-3-g354377c-dirty";
-    constexpr char BuildDate[] = "2019-07-14";
-    constexpr char BuildTime[] = "12:21:07";
+	constexpr char gitVersion[] = "v1.1.1-0-gc184746-dirty";
+	constexpr char compileDate[] = "2022-06-03";
+	constexpr char compileTime[] = "12:28:27";
     #endif
     #ifndef GH_NO_RAW
-    constexpr uint32_t buildTimeUnix = 1653475267;
-    constexpr char versionArray[] = {1, 1, 23, 3}; //Major.Minor.Patch.Offset
-    constexpr uint32_t gitHashHex = 0x354377c;
-    constexpr char dirtyFlag = 1;
+	constexpr uint32_t compileUnixTime = 1654252107;
+    constexpr char tagArray[] = {1, 1, 1, 0}; //Major.Minor.Patch.Offset
+    constexpr char tagPreRelease[] = "";
+    constexpr uint32_t gitHash = 0xc184746;
+    constexpr char gitDirty = 1;
     #endif
-};
+}
 ```
 
 ## Installation
@@ -60,6 +59,8 @@ Add the following lines to your platformio.ini file (uses default Cpp.h template
 ```
 extra_scripts = 
 	pre:GitHashExtractor/firmwareVersion.py
+build_flags =
+  -D GH_NO_TEXT
 ```
 ***
 ### Qt creator with cmake
@@ -87,7 +88,11 @@ add_custom_command(OUTPUT ${VERSION_FILE}
 add_custom_target(GitHashExtractor ALL DEPENDS ${VERSION_FILE})
 # END github.com/ni-m/gitHashExtractor
 ```
-
+### Makefile
+Add the following line to your target
+```
+python3 GitHubExtractor/firmwareVersion.py
+```
 ## Tool configuration
 The following software versions were used to develop this software:
 - VS Code

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Use this repo to extract the current git hash and date information on compile time. It supports various languages as stated in [utilization](#utilization)
 
 ## Requirements
-Use one of the following schemas for your Git tags as described in [Semver2.0.0](https://semver.org/spec/v2.0.0.html)
+Use one of the following schemas for your Git tags as described in [Semver 2.0.0](https://semver.org/spec/v2.0.0.html)
 ```
 1.2.2-alpha
 1.2.2-alpha.3
@@ -31,20 +31,20 @@ gitDirty | 1 for uncommited changes, else 0 | 1 | GH_NO_RAW
 namespace version
 {
     #ifndef GH_NO_URL
-    constexpr char gitURL[] = "";
+        constexpr char gitURL[] = "username/gitrepo";
     #endif
     #ifndef GH_NO_TEXT
-    constexpr char gitVersion[] = "v1.1.1-0-gc184746-dirty";
-    constexpr char compileDate[] = "2022-06-03";
-    constexpr char compileTime[] = "12:28:27";
+        constexpr char gitVersion[] = "v1.1.1-0-gc184746-dirty";
+        constexpr char compDate[] = "2022-06-03";
+        constexpr char compTime[] = "12:28:27";
     #endif
     #ifndef GH_NO_RAW
-    constexpr uint32_t compileUnixTime = 1654252107;
-    constexpr char tagArray[] = {1, 1, 1, 0}; //Major.Minor.Patch
-    constexpr char tagPreRelease[] = "";
-    constexpr char tagOffset = 0;
-    constexpr uint32_t gitHash = 0xc184746;
-    constexpr char gitDirty = 1;
+        constexpr uint32_t compUnixTime = 1654252107;
+        constexpr char tagArray[] = {1, 1, 1, 0}; //Major.Minor.Patch
+        constexpr char tagPreRelease[] = "";
+        constexpr char tagOffset = 0;
+        constexpr uint32_t gitHash = 0xc184746;
+        constexpr char gitDirty = 1;
     #endif
 }
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use one of the following schemas for your Git tags as described in [Semver2.0.0]
 ```
 1.2.2-alpha
 1.2.2-alpha.3
-1.2.2.alpha.beta
+1.2.2-alpha.beta
 v2.3.4-beta
 ```
 
@@ -31,17 +31,18 @@ gitDirty | 1 for uncommited changes, else 0 | 1 | GH_NO_RAW
 namespace version
 {
     #ifndef GH_NO_URL
-	constexpr char gitURL[] = "";
+    constexpr char gitURL[] = "";
     #endif
     #ifndef GH_NO_TEXT
-	constexpr char gitVersion[] = "v1.1.1-0-gc184746-dirty";
-	constexpr char compileDate[] = "2022-06-03";
-	constexpr char compileTime[] = "12:28:27";
+    constexpr char gitVersion[] = "v1.1.1-0-gc184746-dirty";
+    constexpr char compileDate[] = "2022-06-03";
+    constexpr char compileTime[] = "12:28:27";
     #endif
     #ifndef GH_NO_RAW
-	constexpr uint32_t compileUnixTime = 1654252107;
-    constexpr char tagArray[] = {1, 1, 1, 0}; //Major.Minor.Patch.Offset
+    constexpr uint32_t compileUnixTime = 1654252107;
+    constexpr char tagArray[] = {1, 1, 1, 0}; //Major.Minor.Patch
     constexpr char tagPreRelease[] = "";
+    constexpr char tagOffset = 0;
     constexpr uint32_t gitHash = 0xc184746;
     constexpr char gitDirty = 1;
     #endif
@@ -53,14 +54,24 @@ Run the following command in your local git repo: [Troubleshooting](#troubleshoo
 ```
 git submodule add https://github.com/ni-m/GitHashExtractor
 ```
+```
+Git repo:
+├───GitHashExtractor
+│   ├───doc
+│   ├───example
+│   ├───template
+│   ├───firmwareVersion.py
+│   └───version.h
+└───Project files
+```
 ## Utilization
 ### PlatformIO
-Add the following lines to your platformio.ini file (uses default Cpp.h template)
+Add the following lines to your platformio.ini file (uses default Cpp.h template) Adjust flags as needed.
 ```
 extra_scripts = 
-	pre:GitHashExtractor/firmwareVersion.py
+    pre:GitHashExtractor/firmwareVersion.py
 build_flags =
-  -D GH_NO_TEXT
+    -D GH_NO_TEXT
 ```
 ***
 ### Qt creator with cmake

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHashExtractor
 
 ![GitHashExtractor Banner image](./doc/banner.svg)
-Use this repo to extract the current git hash and date information on compile time. It supports various languages as stated in [utilization](#utilization)
+Use this repo to extract the current git hash and date information on compile time. It supports various languages as stated in [utilization](#utilization). Head over to [example](/example/) for a quick look into the working principle.
 
 ## Requirements
 Use one of the following schemas for your Git tags as described in [Semver 2.0.0](https://semver.org/spec/v2.0.0.html)

--- a/example/exampleCpp.cpp
+++ b/example/exampleCpp.cpp
@@ -1,0 +1,36 @@
+/**
+ * @file exampleCpp.cpp
+ * @author ni-m
+ * @brief Example file for version tracking. 
+ * Compile and run with attached makefile or run python script and compiler by yourself
+ * 
+ * @date 2022-06-03
+ * @copyright Copyright (c) 2022
+ * 
+ */
+
+#include "../version.h"
+
+#include <iostream>
+#include <iomanip>
+
+int main(void)
+{
+    std::cout << "=========== version info ===========" << std::endl;
+    std::cout << "Build date: " << version::compileDate << std::endl;
+    std::cout << "GitHash:    0x" << std::hex << version::gitHash << std::dec << std::endl;
+
+    std::cout << "GitTag:     ";
+    for(long unsigned int i = 0; i < 3; ++i)
+    {
+        // cast into int for proper display
+        std::cout << (int)version::tagArray[i];
+        if(i!=2){std::cout << ".";}
+    }  
+    std::cout << std::endl;
+
+    std::cout << "Offset:     " << (int)version::tagArray[3] << std::endl;
+    std::cout << "Prerelease: " << version::tagPreRelease << std::endl;
+    std::cout << "Unixtime:   " << std::dec << version::compileUnixTime << std::endl;
+    return 0;
+}

--- a/example/exampleCpp.cpp
+++ b/example/exampleCpp.cpp
@@ -29,7 +29,7 @@ int main(void)
     }  
     std::cout << std::endl;
 
-    std::cout << "Offset:     " << (int)version::tagArray[3] << std::endl;
+    std::cout << "Offset:     " << (int)version::tagOffset << std::endl;
     std::cout << "Prerelease: " << version::tagPreRelease << std::endl;
     std::cout << "Unixtime:   " << std::dec << version::compileUnixTime << std::endl;
     return 0;

--- a/example/exampleCpp.cpp
+++ b/example/exampleCpp.cpp
@@ -17,7 +17,7 @@
 int main(void)
 {
     std::cout << "=========== version info ===========" << std::endl;
-    std::cout << "Build date: " << version::compileDate << std::endl;
+    std::cout << "Build date: " << version::compDate << std::endl;
     std::cout << "GitHash:    0x" << std::hex << version::gitHash << std::dec << std::endl;
 
     std::cout << "GitTag:     ";
@@ -31,6 +31,6 @@ int main(void)
 
     std::cout << "Offset:     " << (int)version::tagOffset << std::endl;
     std::cout << "Prerelease: " << version::tagPreRelease << std::endl;
-    std::cout << "Unixtime:   " << std::dec << version::compileUnixTime << std::endl;
+    std::cout << "Unixtime:   " << std::dec << version::compUnixTime << std::endl;
     return 0;
 }

--- a/example/makefile
+++ b/example/makefile
@@ -1,0 +1,20 @@
+CC = g++
+LINK = g++
+CFLAGS = -c -Wall -pedantic
+LFLAGS = -Wall -pedantic
+OBJS = exampleCpp.o
+EXE = exampleCpp
+
+exampleCppRun: exampleCpp
+	./$(EXE)
+
+exampleCpp: $(OBJS)
+	python3 ../firmwareVersion.py
+	$(LINK) $(LFLAGS) -o $(EXE) $(OBJS)
+
+exampleCpp.o:exampleCpp.cpp
+	$(CC) $(CFLAGS) exampleCpp.cpp
+
+clean:
+	@echo Clean all auto-generated files
+	rm -f $(EXE) $(OBJS)

--- a/example/makefile
+++ b/example/makefile
@@ -9,10 +9,10 @@ exampleCppRun: exampleCpp
 	./$(EXE)
 
 exampleCpp: $(OBJS)
-	python3 ../firmwareVersion.py
 	$(LINK) $(LFLAGS) -o $(EXE) $(OBJS)
 
 exampleCpp.o:exampleCpp.cpp
+	python3 ../firmwareVersion.py
 	$(CC) $(CFLAGS) exampleCpp.cpp
 
 clean:

--- a/example/readme.md
+++ b/example/readme.md
@@ -5,7 +5,16 @@ This example shows the usage of the GitHashExtractor.
 ## Run
 Execute ```make``` in the example folder. Make sure to have python and g++ installed and ready.
 
-As an alternative run the script by yourself via ```python3 firmwareVersion.py``` and compile the cpp file with the compiler of your choice.
+Alternatively, you can run the script by yourself via ```python3 firmwareVersion.py``` and compile the cpp file with the compiler of your choice.
 
 ## Output
-The example file prints out some important stats about your parent repo.
+The example file prints out some stats about your parent repo:
+```
+=========== version info ===========
+Build date: 2022-06-06
+GitHash:    0xc184746
+GitTag:     0.9.3
+Offset:     0
+Prerelease: alpha.3
+Unixtime:   1654546309
+```

--- a/example/readme.md
+++ b/example/readme.md
@@ -1,0 +1,11 @@
+# Cpp example
+
+This example shows the usage of the GitHashExtractor.
+
+## Run
+Execute ```make``` in the example folder. Make sure to have python and g++ installed and ready.
+
+As an alternative run the script by yourself via ```python3 firmwareVersion.py``` and compile the cpp file with the compiler of your choice.
+
+## Output
+The example file prints out some important stats about your parent repo.

--- a/template/templateCpp.h
+++ b/template/templateCpp.h
@@ -23,14 +23,15 @@ namespace templateNamespace
 	constexpr char gitURL[] = "GH_GITURL";
     #endif
     #ifndef GH_NO_TEXT
-	constexpr char gitHash[] = "GH_VERSION";
-	constexpr char BuildDate[] = "GH_DATE";
-	constexpr char BuildTime[] = "GH_TIME";
+	constexpr char gitVersion[] = "GH_VERSION";
+	constexpr char compileDate[] = "GH_DATE";
+	constexpr char compileTime[] = "GH_TIME";
     #endif
     #ifndef GH_NO_RAW
-	constexpr uint32_t buildTimeUnix = GH_UNIXTIME;
-    constexpr char versionArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH, GH_OFFSET}; //Major.Minor.Patch.Offset
-    constexpr uint32_t gitHashHex = GH_GITHASHHEX;
-    constexpr char dirtyFlag = GH_DIRTYFLAG;
+	constexpr uint32_t compileUnixTime = GH_UNIXTIME;
+    constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH, GH_OFFSET}; //Major.Minor.Patch.Offset
+    constexpr char tagPreRelease[] = "GH_PRERELEASE";
+    constexpr uint32_t gitHash = GH_GITHASHHEX;
+    constexpr char gitDirty = GH_DIRTYFLAG;
     #endif
 }

--- a/template/templateCpp.h
+++ b/template/templateCpp.h
@@ -29,8 +29,9 @@ namespace templateNamespace
     #endif
     #ifndef GH_NO_RAW
 	constexpr uint32_t compileUnixTime = GH_UNIXTIME;
-    constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH, GH_OFFSET}; //Major.Minor.Patch.Offset
+    constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH}; //Major.Minor.Patch
     constexpr char tagPreRelease[] = "GH_PRERELEASE";
+    constexpr char tagOffset = GH_OFFSET;
     constexpr uint32_t gitHash = GH_GITHASHHEX;
     constexpr char gitDirty = GH_DIRTYFLAG;
     #endif

--- a/template/templateCpp.h
+++ b/template/templateCpp.h
@@ -20,19 +20,19 @@
 namespace templateNamespace
 {
     #ifndef GH_NO_URL
-	constexpr char gitURL[] = "GH_GITURL";
+        constexpr char gitURL[] = "GH_GITURL";
     #endif
     #ifndef GH_NO_TEXT
-	constexpr char gitVersion[] = "GH_VERSION";
-	constexpr char compileDate[] = "GH_DATE";
-	constexpr char compileTime[] = "GH_TIME";
+        constexpr char gitVersion[] = "GH_VERSION";
+        constexpr char compDate[] = "GH_DATE";
+        constexpr char compTime[] = "GH_TIME";
     #endif
     #ifndef GH_NO_RAW
-	constexpr uint32_t compileUnixTime = GH_UNIXTIME;
-    constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH}; //Major.Minor.Patch
-    constexpr char tagPreRelease[] = "GH_PRERELEASE";
-    constexpr char tagOffset = GH_OFFSET;
-    constexpr uint32_t gitHash = GH_GITHASHHEX;
-    constexpr char gitDirty = GH_DIRTYFLAG;
+        constexpr uint32_t compUnixTime = GH_UNIXTIME;
+        constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH}; //Major.Minor.Patch
+        constexpr char tagPreRelease[] = "GH_PRERELEASE";
+        constexpr char tagOffset = GH_OFFSET;
+        constexpr uint32_t gitHash = GH_GITHASHHEX;
+        constexpr char gitDirty = GH_DIRTYFLAG;
     #endif
 }

--- a/template/templateQt.h
+++ b/template/templateQt.h
@@ -17,19 +17,19 @@
 namespace templateNamespace
 {
     #ifndef GH_NO_URL
-    QString gitURL = "GH_GITURL";
+        QString gitURL = "GH_GITURL";
     #endif
     #ifndef GH_NO_TEXT
-    QString gitVersion = "GH_VERSION";
-    QString compileDate = "GH_DATE";
-    QString compileTime = "GH_TIME";
+        QString gitVersion = "GH_VERSION";
+        QString compDate = "GH_DATE";
+        QString compTime = "GH_TIME";
     #endif
     #ifndef GH_NO_RAW
-	constexpr uint32_t compileUnixTime = GH_UNIXTIME;
-    constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH}; //Major.Minor.Patch
-    constexpr QString tagPreRelease = "GH_PRERELEASE";
-    constexpr char tagOffset = GH_OFFSET;
-    constexpr uint32_t gitHash = GH_GITHASHHEX;
-    constexpr char gitDirty = GH_DIRTYFLAG;
+        constexpr uint32_t compUnixTime = GH_UNIXTIME;
+        constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH}; //Major.Minor.Patch
+        constexpr QString tagPreRelease = "GH_PRERELEASE";
+        constexpr char tagOffset = GH_OFFSET;
+        constexpr uint32_t gitHash = GH_GITHASHHEX;
+        constexpr char gitDirty = GH_DIRTYFLAG;
     #endif
 }

--- a/template/templateQt.h
+++ b/template/templateQt.h
@@ -26,8 +26,9 @@ namespace templateNamespace
     #endif
     #ifndef GH_NO_RAW
 	constexpr uint32_t compileUnixTime = GH_UNIXTIME;
-    constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH, GH_OFFSET}; //Major.Minor.Patch.Offset
+    constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH}; //Major.Minor.Patch
     constexpr QString tagPreRelease = "GH_PRERELEASE";
+    constexpr char tagOffset = GH_OFFSET;
     constexpr uint32_t gitHash = GH_GITHASHHEX;
     constexpr char gitDirty = GH_DIRTYFLAG;
     #endif

--- a/template/templateQt.h
+++ b/template/templateQt.h
@@ -20,14 +20,15 @@ namespace templateNamespace
     QString gitURL = "GH_GITURL";
     #endif
     #ifndef GH_NO_TEXT
-    QString gitHash = "GH_VERSION";
-    QString BuildDate = "GH_DATE";
-    QString BuildTime = "GH_TIME";
+    QString gitVersion = "GH_VERSION";
+    QString compileDate = "GH_DATE";
+    QString compileTime = "GH_TIME";
     #endif
     #ifndef GH_NO_RAW
-	uint32_t buildTimeUnix = GH_UNIXTIME;
-    char versionArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH, GH_OFFSET}; //Major.Minor.Patch.Offset
-    uint32_t gitHashHex = GH_GITHASHHEX;
-    char dirtyFlag = GH_DIRTYFLAG;
+	constexpr uint32_t compileUnixTime = GH_UNIXTIME;
+    constexpr char tagArray[] = {GH_MAJOR, GH_MINOR, GH_PATCH, GH_OFFSET}; //Major.Minor.Patch.Offset
+    constexpr QString tagPreRelease = "GH_PRERELEASE";
+    constexpr uint32_t gitHash = GH_GITHASHHEX;
+    constexpr char gitDirty = GH_DIRTYFLAG;
     #endif
 }


### PR DESCRIPTION
## Consistent naming
Finalized naming convention for all available variables.

## Sample project
Add a cpp project with a makefile to show how to use GitHashExtractor.